### PR TITLE
Add consent example

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -17,19 +17,38 @@
       can
       open the Developer Console and play around with the API. (F12)
     </p>
+    <br />
     <h2>Loading the script</h2>
     <code style="max-width:800px;width:100%;margin:0 auto;white-space:break-spaces">
 &lt;script&gt;
 (function (d, a, t, h, u, i, s) { d["DatHuisObject"] = u; d[u] = d[u] || function () { (d[u].q = d[u].q || []).push(arguments) }; d[u].l = 1 * new Date; se = a.createElement(t); fs = a.getElementsByTagName(t)[0]; se["async"] = 1; se.src = h; fs.parentNode.insertBefore(se, fs) })(window, document, "script", "https://btstrp.dathuis.nl/assets/iframeBridge.min.js", "iFrameBridge");
+
+// Defining onConsent callback to receive the consent object
+iFrameBridge.onConsent = (args) => {
+  // Set received consent args to the variable of your choice
+  window.__DH_CC_CONSENT_PARAMS = args;
+};
+
 iFrameBridge('init');
 &lt;/script&gt;
     </code>
+    <h3>Consent object is:</h3>
+    <code style="max-width:800px;width:100%;margin:0 auto;white-space:break-spaces">
+      {
+        "ad_storage": 'granted' | 'denied',
+        "ad_user_data": 'granted' | 'denied',
+        "ad_personalization": 'granted' | 'denied',
+        "analytics_storage": 'granted' | 'denied'
+      }
+    </code>
+    <br />
     <h2>Now the <code>iFrameBridge</code> space should be available</h2>
     <p class="description">Try:
       <code>
 iFrameBridge('track', { name: 'test_event' });
 </code>
     </p>
+    <br />
     <p>When you want to flag the event as a conversion event:</p>
     <code>
 iFrameBridge('track', { name: 'test_event', conversion: true });
@@ -48,6 +67,11 @@ iFrameBridge('track', { name: 'test_event', conversion: true });
   </main>
   <script>
     (function (d, a, t, h, u, i, s) { d["DatHuisObject"] = u; d[u] = d[u] || function () { (d[u].q = d[u].q || []).push(arguments) }; d[u].l = 1 * new Date; se = a.createElement(t); fs = a.getElementsByTagName(t)[0]; se["async"] = 1; se.src = h; fs.parentNode.insertBefore(se, fs) })(window, document, "script", "https://btstrp.dathuis.nl/assets/iframeBridge.min.js", "iFrameBridge");
+    // Defining onConsent function here to receive the consent object
+    iFrameBridge.onConsent = (args) => {
+      // Set received consent args to the variable of your choice
+      window.__DH_CC_CONSENT_PARAMS = args;
+    };
     iFrameBridge('init');
   </script>
 </body>

--- a/nextjs/pages/index.tsx
+++ b/nextjs/pages/index.tsx
@@ -26,12 +26,30 @@ export default function Home() {
             `
 <script>
   (function (d, a, t, h, u, i, s) { d["DatHuisObject"] = u; d[u] = d[u] || function () { (d[u].q = d[u].q || []).push(arguments) }; d[u].l = 1 * new Date; se = a.createElement(t); fs = a.getElementsByTagName(t)[0]; se["async"] = 1; se.src = h; fs.parentNode.insertBefore(se, fs) })(window, document, "script", "https://btstrp.dathuis.nl/assets/iframeBridge.min.js", "iFrameBridge");
+   
+  // Defining onConsent callback to receive the consent object
+    iFrameBridge.onConsent = (args) => {
+      // Set received consent args to the variable of your choice
+      window.__DH_CC_CONSENT_PARAMS = args;
+    };
+
   iFrameBridge('init');
 </script>
             `
           }
         </code>
-
+      <h3>Consent object is:</h3>
+      <code style={{maxWidth: '800px', width: '100%', margin: '0 auto', whiteSpace: 'break-spaces'}}>
+      {`
+      {
+        "ad_storage": 'granted' | 'denied',
+        "ad_user_data": 'granted' | 'denied',
+        "ad_personalization": 'granted' | 'denied',
+        "analytics_storage": 'granted' | 'denied'
+      }
+      `}
+    </code>
+    <br />
         <h2>Now the <code>iFrameBridge</code> space should be available</h2>
         <p>
           Try:


### PR DESCRIPTION
This PR adds an example of `onConsent` callback implementation, which is needed to receive the consent object from the parent webpage. See the documentation [here](https://public.app.shortcut.com/c8/dathuis/docs/33RBcGPPppKKR29v90XsL7/dathuis-iframebridge-technical-documentation).